### PR TITLE
Restore original stderr and stdout functionality. Handle filenames with parens.

### DIFF
--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -228,6 +228,7 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
             cur_cleanup.append(sam_file)
             bam_file_all = sam_file[:-4] + ".all.bam"
             bam_file_aligned = sam_file[:-4] + ".aligned.bam"
+            bam_file_sort_name = sam_file[:-4] + ".aligned.name.bam"
             fastq_file_aligned = sam_file[:-4] + ".aligned.fq"
             # fastq_file_aligned1 = sam_file[:-4] + ".aligned.1.fq"
             fastq_file_aligned2 = sam_file[:-4] + ".aligned.2.fq"
@@ -266,11 +267,18 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
                     shell=True,
                     check=True,
                 )
+                sort_name_cmd = [
+                    "samtools",
+                    "sort",
+                    "-n",
+                    bam_file_aligned,
+                    bam_file_sort_name,
+                ]
                 bam2fq_cmd = [
                     "bedtools",
                     "bamtofastq",
                     "-i",
-                    bam_file_aligned,
+                    bam_file_sort_name,
                     "-fq",
                     fastq_file_aligned,
                 ]
@@ -279,6 +287,9 @@ def run_alignment(genome_list, read_list, parameters, output_dir, job_data):
                 if read2:  # paired end
                     bam2fq_cmd += ["-fq2", fastq_file_aligned2]
                     bam2fqgz_cmd += [fastq_file_aligned2]
+                print(" ".join(sort_name_cmd))
+                # Need to sort by name to convert to fastq: samtools sort -n myBamFile.bam myBamFile.sortedByName
+                subprocess.run(sort_name_cmd, check=True)
                 print((" ".join(bam2fq_cmd)))
                 subprocess.run(bam2fq_cmd, check=True)
                 subprocess.run(bam2fqgz_cmd, check=True)

--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -442,6 +442,13 @@ def setup(job_data, output_dir, tool_params):
                         elif f.endswith("fastqc.html"):
                             r["fastqc"].append(os.path.join(target_dir, f))
     recipe = job_data.get("recipe", [])
+    for r in read_list:
+        if "read" in r:
+            r["read"] = moveRead(r["read"])
+        if "read1" in r:
+            r["read1"] = moveRead(r["read1"])
+        if "read2" in r:
+            r["read2"] = moveRead(r["read2"])
     return genome_list, read_list, recipe
 
 
@@ -449,6 +456,17 @@ def gzipMove(source, dest):
     with open(source, "rb") as f_in:
         with gzip.open(dest, "wb") as f_out:
             shutil.copyfileobj(f_in, f_out)
+
+
+def moveRead(filepath):
+    directory, base = os.path.split(filepath)
+    new_base = base.replace(")", "_").replace("(", "_")
+    if new_base != base:
+        newpath = os.path.join(directory, new_base)
+        os.rename(filepath, newpath)
+        return newpath
+    else:
+        return filepath
 
 
 def run_fq_util(job_data, output_dir, tool_params={}):

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -174,18 +174,19 @@ sub process_fastq
 
     warn Dumper(\@cmd, $params_to_app);
 
-    my $ok = run(\@cmd,
-		 ">", "$work_dir/fqutils.out.txt",
-		 "2>", "$work_dir/fqutils.err.txt");
+    my $ok = run(\@cmd);
+    # my $ok = run(\@cmd,
+	# 	 ">", "$work_dir/fqutils.out.txt",
+	# 	 "2>", "$work_dir/fqutils.err.txt");
     if (!$ok)
     {
-        opendir(D, $work_dir) or die "Cannot opendir $work_dir: $!";
-        $app->workspace->save_file_to_file("$work_dir/fqutils.out.txt", {}, "$output_folder/fqutils.out.txt", "txt", 1,
-                            (-s "$work_dir/fqutils.out.txt" > 10_000 ? 1 : 0), # use shock for larger files
-                            $token);
-        $app->workspace->save_file_to_file("$work_dir/fqutils.err.txt", {}, "$output_folder/fqutils.err.txt", "txt", 1,
-        (-s "$work_dir/fqutils.err.txt" > 10_000 ? 1 : 0), # use shock for larger files
-        $token);
+        # opendir(D, $work_dir) or die "Cannot opendir $work_dir: $!";
+        # $app->workspace->save_file_to_file("$work_dir/fqutils.out.txt", {}, "$output_folder/fqutils.out.txt", "txt", 1,
+        #                     (-s "$work_dir/fqutils.out.txt" > 10_000 ? 1 : 0), # use shock for larger files
+        #                     $token);
+        # $app->workspace->save_file_to_file("$work_dir/fqutils.err.txt", {}, "$output_folder/fqutils.err.txt", "txt", 1,
+        # (-s "$work_dir/fqutils.err.txt" > 10_000 ? 1 : 0), # use shock for larger files
+        # $token);
 	    die "Command failed: @cmd\n";
     }
 

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -163,7 +163,8 @@ sub process_fastq
 	bowtie2 => {-p => $parallel},
 	hisat2 => {-p => $parallel},
 	samtools_view => {-p => $parallel},
-	samtools_index => {-p => $parallel}
+	samtools_index => {-p => $parallel},
+    samtools_sort => {-p => $parallel}
     };
 
     my @cmd = ("p3-fqutils",

--- a/test/align_output.json
+++ b/test/align_output.json
@@ -1,0 +1,14 @@
+{
+    "output_path": "/jsporter@patricbrc.org/home/Test_Files",
+    "output_file": "fqutils_output",
+    "reference_genome_id": "93061.5",
+    "paired_end_libs": [
+        {
+                    "read1": "/jsporter@patricbrc.org/home/Test_Files/331_S13_L001_R1_001.fastq",
+                    "read2": "/jsporter@patricbrc.org/home/Test_Files/331_S13_L001_R2_001.fastq"
+                }
+    ],
+    "recipe": [
+        "Align"
+    ]
+}

--- a/test/parens_jira_4678.json
+++ b/test/parens_jira_4678.json
@@ -1,0 +1,13 @@
+{
+    "output_path": "/jsporter@patricbrc.org/JSP_debug/lfpantojad22",
+    "output_file": "TS1_Trim",
+    "paired_end_libs": [
+        {
+	            "read1": "/jsporter@patricbrc.org/JSP_debug/lfpantojad22/TS1.IS350_Clean.1 (5).fq",
+	            "read2": "/jsporter@patricbrc.org/JSP_debug/lfpantojad22/TS1.IS350_Clean.2 (1).fq"
+	        }
+    ],
+    "recipe": [
+        "Trim"
+    ]
+}


### PR DESCRIPTION
This restores the original live stderr and stdout functionality. The bedtools bam2fasta stderr is directed to a log file since it is what was creating such large output.  It sorts the bam file before creating the fasta file for alignments, and this should reduce bedtools output. This was happening with paired end data.

Filenames with parens in them were causing jobs to fail, so those files are copied so that the parens are replaced with underscores.