### PR TITLE
Only use minimap2 when there are no paired reads (and no hisat2 index). Fix perl string compare bug.

### DIFF
--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -124,7 +124,7 @@ sub process_fastq
     {
 	for my $read_name (keys %{$read_tuple})
 	{
-	   if($read_name == "read1" || $read_name == "read2")
+	   if($read_name eq "read1" || $read_name eq "read2")
            {
 	       my $nameref = \$read_tuple->{$read_name};
 	       $in_files{$$nameref} = $nameref;
@@ -136,7 +136,7 @@ sub process_fastq
     {
 	for my $read_name (keys %{$read_tuple})
 	{
-	   if($read_name == "read")
+	   if($read_name eq "read")
            {
 	       my $nameref = \$read_tuple->{$read_name};
 	       $in_files{$$nameref} = $nameref;


### PR DESCRIPTION
The string comparison bug commit should definitely be merged.

The minimap2 change should do what we want, given the current way run_aligment is desiged.
But that code should probably ultimately be refactored to unwrap and/or separate the two loops, so we can truly utilize the platform information in a robust way.