### PR TITLE
add test jobdesc files for pacbio and nanopore sra reads

### DIFF
--- a/test/long_nanopore_sra_jobdesc.json
+++ b/test/long_nanopore_sra_jobdesc.json
@@ -1,0 +1,16 @@
+{
+  "reference_genome_id": "359391.4",
+  "output_file": "test_nanopore_long",
+  "recipe": [
+    "FASTQC",
+    "TRIM",
+    "ALIGN"
+  ],
+  "output_path": "/briandk@bv-brc.org/home/ac.briandk/products/fqutils_test/output",
+  "srr_libs": [
+    {
+      "platform": "nanopore",
+      "srr_accession": "SRR24087961"
+    }
+  ]
+}

--- a/test/long_pacbio_sra_jobdesc.json
+++ b/test/long_pacbio_sra_jobdesc.json
@@ -1,0 +1,16 @@
+{
+  "reference_genome_id": "83332.12",
+  "output_file": "test_pacbio_long",
+  "recipe": [
+    "FASTQC",
+    "TRIM",
+    "ALIGN"
+  ],
+  "output_path": "/briandk@bv-brc.org/home/ac.briandk/products/fqutils_test/output",
+  "srr_libs": [
+    {
+      "platform": "pacbio",
+      "srr_accession": "SRR20998249"
+    }
+  ]
+}


### PR DESCRIPTION
These are sra test reads which Rebecca pointed me to.
I'm not sure if we additionally want to have tests for locally-stored reads.