### PR TITLE
Hostile: include a file with the tool's default output "log" (basically a short summary, in json format)

### DIFF
--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -464,8 +464,10 @@ def run_hostile(read_list, output_dir, job_data, tool_params):
     cache_dir = output_dir / "hostile"
     cache_dir.mkdir(exist_ok=True, parents=True)
     os.environ["HOSTILE_CACHE_DIR"] = str(cache_dir)
-
     print(f"{os.environ['HOSTILE_CACHE_DIR']=}", file=sys.stderr)
+
+    log_path = output_dir / "hostile_log.json"
+    print(f"{log_path=}", file=sys.stderr)
 
     cmd = ["hostile", "clean", "--force",
            "--out-dir", str(output_dir), "--fastq1"]
@@ -477,7 +479,8 @@ def run_hostile(read_list, output_dir, job_data, tool_params):
         else:
             cmd += [r["read"],]
 
-        subprocess.run(cmd, check=True)
+        with log_path.open('w') as log_hdl:
+            subprocess.run(cmd, check=True, stdout=log_hdl)
 
 def get_genome(parameters, host_manifest={}):
     target_file = os.path.join(parameters["output_path"], parameters["gid"] + ".fna")

--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -466,7 +466,7 @@ def run_hostile(read_list, output_dir, job_data, tool_params):
     os.environ["HOSTILE_CACHE_DIR"] = str(cache_dir)
     print(f"{os.environ['HOSTILE_CACHE_DIR']=}", file=sys.stderr)
 
-    log_path = output_dir / "hostile_log.json"
+    log_path = output_dir / "hostile_report.txt"
     print(f"{log_path=}", file=sys.stderr)
 
     cmd = ["hostile", "clean", "--force",

--- a/service-scripts/App-FastqUtils.pl
+++ b/service-scripts/App-FastqUtils.pl
@@ -207,7 +207,8 @@ sub process_fastq
 			   [qr/\.bai$/, "bai"],
 			   [qr/\.html$/, "html"],
 			   [qr/\.fastq\.gz$/, "reads"],
-			   [qr/\.txt$/, "txt"]);
+			   [qr/\.txt$/, "txt"],
+			   [qr/\.json$/, "json"]);
 
     my $outfile;
     opendir(D, $work_dir) or die "Cannot opendir $work_dir: $!";


### PR DESCRIPTION
Short of creating a better-formatted output report, we can at least have this useful file among the tool's output files.

I agree that it can be nice to have something like an html report. I just don't know if it is worth it, creating and maintaining special ad-hoc boutique ones, per tool.