### PR TITLE
Try to fix Jira BVBRC-1493, java.lang.OutOfMemoryError

### DIFF
--- a/lib/fastq_utils.py
+++ b/lib/fastq_utils.py
@@ -47,7 +47,7 @@ def get_param(program, feature, tool_params):
 def run_fastqc(read_list, output_dir, job_data, tool_params):
     rcount = 0
     threads = get_param("fastqc", "-p", tool_params)
-    fastqc_base_cmd = ["fastqc", "-t", str(threads) if threads else "1"]
+    fastqc_base_cmd = ["fastqc", "--memory", "4096", "-t", str(threads) if threads else "8"]
     for r in read_list:
         rcount += 1
         if len(r.get("fastqc", [])) == 0:

--- a/test/Jira_BVBRC-1493.json
+++ b/test/Jira_BVBRC-1493.json
@@ -1,0 +1,12 @@
+{
+    "recipe": [
+        "FastQC"
+    ],
+    "output_path": "/briandk@bvbrc/home/bugs/BVBRC-1493",
+    "output_file": "test001",
+    "srr_libs": [
+        {
+            "srr_accession": "SRR20184597"
+        }
+    ]
+}


### PR DESCRIPTION
by bumping memory and threads.

At first only the thread bump helped. Then, later, it seemed to also need a memory bump.

I kept the test file to pull from SRA, because that is exactly the one/part that ended the job in the user's bug.